### PR TITLE
[fixesproto]: Add inspec tests and update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-results
+results/
+inspec.lock

--- a/README.md
+++ b/README.md
@@ -1,15 +1,64 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.fixesproto?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=210&branchName=master)
+
 # fixesproto
 
-X.Org Protocol Headers: fixesproto
+fixesproto is an X Fixes extension protocol specification and header files.  This extension makes changes to many areas of the protocol to resolve issues raised by application interaction with core protocol mechanisms that cannot be adequately worked around on the client side of the wire. See [documentation](https://cgit.freedesktop.org/xorg/proto/fixesproto)
 
 ## Maintainers
 
-* The Habitat Maintainers: <humans@habitat.sh>
+* The Core Planners: <chef-core-planners@chef.io>
 
 ## Type of Package
 
-Binary package
+Library package
 
-## Usage
+### Use as Dependency
 
-*TODO: Add instructions for usage*
+Library packages can be set as runtime or build time dependencies, however they are typically used as buildtime dependencies. See [Defining your dependencies](https://www.habitat.sh/docs/developing-packages/developing-packages/#sts=Define%20Your%20Dependencies) for more information.
+
+To add core/fixesproto as a dependency, you can add one of the following to your plan file.
+
+#### Buildtime Dependency
+
+> pkg_build_deps=(core/fixesproto)
+
+#### Runtime Dependency
+
+> pkg_deps=(core/fixesproto)
+
+### Use as a Library
+
+#### Installation
+
+To install this plan, run the following command:
+
+``hab pkg install core/fixesproto``
+
+```bash
+hab pkg install core/fixesproto
+» Installing core/fixesproto
+☁ Determining latest version of core/fixesproto in the 'stable' channel
+→ Found newer installed version (core/fixesproto/5.0/20200828132129) than remote version (core/fixesproto/5.0/20200404121548)
+→ Using core/fixesproto/5.0/20200828132129
+★ Install of core/fixesproto/5.0/20200828132129 complete with 0 new packages installed.
+```
+
+#### Viewing library files
+
+To view the library files first get the habitat installation directory
+
+```bash
+$ hab pkg path core/fixesproto
+/hab/pkgs/core/fixesproto/5.0/20200828132129
+```
+
+Then list the libraries, for example:
+
+```bash
+ls -1 $(hab pkg path core/fixesproto)
+include
+lib
+share
+...
+...
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# fixesproto
+
+X.Org Protocol Headers: fixesproto
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,2 @@
+plan_name: 'fixesproto'
+pkgconfig_filename: 'fixesproto.pc'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,4 +15,4 @@ resources:
 
 # Execute the stages from the main pipeline template
 stages:
-  - template: azure-pipelines.yml@plan_builder
+  - template: azure-pipelines-package-install.yml@plan_builder

--- a/botanist.yml
+++ b/botanist.yml
@@ -1,0 +1,4 @@
+---
+owners:
+  - "@smacfarlane"
+  - "@habitat-sh/habitat-core-plans-maintainers"

--- a/controls/fixesproto_library_exists.rb
+++ b/controls/fixesproto_library_exists.rb
@@ -1,0 +1,38 @@
+title 'Tests to confirm fixesproto library exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'fixesproto')
+
+control 'core-plans-fixesproto-library-exists' do
+  impact 1.0
+  title 'Ensure fixesproto library exists'
+  desc '
+  Verify fixesproto library by ensuring that 
+  (1) its installation directory exists; 
+  (2) the library exists; 
+  (3) its pkgconfig metadata contains the expected version
+  '
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  # library_filename = input('library_filename', value: 'fixesproto.so')
+  # library_full_path = File.join(plan_installation_directory.stdout.strip, 'lib', library_filename)
+  # describe file(library_full_path) do
+  #   it { should exist }
+  # end
+
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
+  pkgconfig_filename = input('pkgconfig_filename', value: 'fixesproto.pc')
+  pkgconfig_full_path = File.join(plan_installation_directory.stdout.strip, 'lib', 'pkgconfig', pkgconfig_filename)
+  describe command("cat #{pkgconfig_full_path}") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /Version:\s+#{plan_pkg_version}/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/controls/fixesproto_library_exists.rb
+++ b/controls/fixesproto_library_exists.rb
@@ -33,6 +33,5 @@ control 'core-plans-fixesproto-library-exists' do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
     its('stdout') { should match /Version:\s+#{plan_pkg_version}/ }
-    its('stderr') { should be_empty }
   end
 end

--- a/hooks/run
+++ b/hooks/run
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-exec 2>&1
-
-while true; do
-  echo "Sleeping ..."
-  sleep 10
-done

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {plan}
-title: Habitat Core Plan {plan}
+name: fixesproto
+title: Habitat Core Plan fixesproto
 maintainer: "The Core Planners <chef-core-planners@chef.io>"
-summary: InSpec controls for testing Habitat Core Plan {plan}
+summary: InSpec controls for testing Habitat Core Plan fixesproto
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 4.18.108'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,17 @@
+pkg_name=fixesproto
+pkg_origin=core
+pkg_version=5.0
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="X.Org Protocol Headers: fixesproto"
+pkg_upstream_url="https://www.x.org/"
+pkg_license=('MIT')
+pkg_source="https://www.x.org/releases/individual/proto/${pkg_name}-${pkg_version}.tar.bz2"
+pkg_shasum="ba2f3f31246bdd3f2a0acf8bd3b09ba99cab965c7fb2c2c92b7dc72870e424ce"
+pkg_build_deps=(
+  core/gcc
+  core/make
+  core/pkg-config
+  core/util-macros
+)
+pkg_include_dirs=(include)
+pkg_pconfig_dirs=(lib/pkgconfig)


### PR DESCRIPTION
No library files present only header files.

tests all passing in studio:

```rspec

Profile: Habitat Core Plan fixesproto (fixesproto)
Version: 0.1.0
Target:  local://

  ✔  core-plans-fixesproto-library-exists: Ensure fixesproto library exists
     ✔  Command: `hab pkg path core/fixesproto` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/fixesproto` stdout is expected not to be empty
     ✔  Command: `cat /hab/pkgs/core/fixesproto/5.0/20200828132129/lib/pkgconfig/fixesproto.pc` exit_status is expected to eq 0
     ✔  Command: `cat /hab/pkgs/core/fixesproto/5.0/20200828132129/lib/pkgconfig/fixesproto.pc` stdout is expected not to be empty
     ✔  Command: `cat /hab/pkgs/core/fixesproto/5.0/20200828132129/lib/pkgconfig/fixesproto.pc` stdout is expected to match /Version:\s+5.0/
     ✔  Command: `cat /hab/pkgs/core/fixesproto/5.0/20200828132129/lib/pkgconfig/fixesproto.pc` stderr is expected to be empty


Profile Summary: 1 successful control, 0 control failures, 0 controls skipped
Test Summary: 6 successful, 0 failures, 0 skipped
```